### PR TITLE
[add] Rest로 변경 - Dto, controller 구현 및 테스트

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -15,6 +15,13 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 
+	// REST
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// MapStruct
+	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+
 	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/backend/src/main/generated/com/lewns2/backend/mapper/MemberMapperImpl.java
+++ b/backend/src/main/generated/com/lewns2/backend/mapper/MemberMapperImpl.java
@@ -1,0 +1,41 @@
+package com.lewns2.backend.mapper;
+
+import com.lewns2.backend.model.Member;
+import com.lewns2.backend.rest.dto.MemberDto;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2023-01-30T01:17:07+0900",
+    comments = "version: 1.5.3.Final, compiler: javac, environment: Java 11.0.13 (Azul Systems, Inc.)"
+)
+public class MemberMapperImpl implements MemberMapper {
+
+    @Override
+    public MemberDto toMemberDto(Member member) {
+        if ( member == null ) {
+            return null;
+        }
+
+        String email = null;
+
+        email = member.getEmail();
+
+        MemberDto memberDto = new MemberDto( email );
+
+        return memberDto;
+    }
+
+    @Override
+    public Member toMember(MemberDto memberDto) {
+        if ( memberDto == null ) {
+            return null;
+        }
+
+        Member member = new Member();
+
+        member.setEmail( memberDto.getEmail() );
+
+        return member;
+    }
+}

--- a/backend/src/main/java/com/lewns2/backend/mapper/MemberMapper.java
+++ b/backend/src/main/java/com/lewns2/backend/mapper/MemberMapper.java
@@ -1,0 +1,16 @@
+package com.lewns2.backend.mapper;
+
+import com.lewns2.backend.model.Member;
+import com.lewns2.backend.rest.dto.MemberDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface MemberMapper {
+
+    MemberMapper INSTANCE = Mappers.getMapper(MemberMapper.class);
+
+    MemberDto toMemberDto(Member member);
+
+    Member toMember(MemberDto memberDto);
+}

--- a/backend/src/main/java/com/lewns2/backend/rest/controller/MemberRestController.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/controller/MemberRestController.java
@@ -1,0 +1,44 @@
+package com.lewns2.backend.rest.controller;
+
+import com.lewns2.backend.mapper.MemberMapper;
+import com.lewns2.backend.model.Member;
+import com.lewns2.backend.rest.dto.MemberDto;
+import com.lewns2.backend.service.MemberService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+public class MemberRestController {
+
+    private final MemberService memberService;
+    private final MemberMapper memberMapper;
+
+    // 생성자
+    public MemberRestController(MemberService memberService, MemberMapper memberMapper) {
+        this.memberService = memberService;
+        this.memberMapper = memberMapper;
+    }
+
+    // 회원 등록
+    @PostMapping("/members")
+    public ResponseEntity<MemberDto> saveMember(@RequestBody MemberDto memberDto) {
+        /* 1. 요청 memberDto를 member 엔티티로 변환
+        // 2. 서비스 호출 : 등록
+        // 3, dto를 반환 */
+        HttpHeaders headers = new HttpHeaders();
+
+        Member member = memberMapper.toMember(memberDto);
+        memberService.doSignUp(member);
+
+        return new ResponseEntity<>(memberMapper.toMemberDto(member), headers, HttpStatus.CREATED);
+
+
+    }
+}

--- a/backend/src/main/java/com/lewns2/backend/rest/dto/MemberDto.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/dto/MemberDto.java
@@ -1,0 +1,17 @@
+package com.lewns2.backend.rest.dto;
+
+public class MemberDto {
+    private String email;
+
+    public MemberDto(String email) {
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/backend/src/test/java/com/lewns2/backend/mapper/MemberMapperTests.java
+++ b/backend/src/test/java/com/lewns2/backend/mapper/MemberMapperTests.java
@@ -1,0 +1,45 @@
+package com.lewns2.backend.mapper;
+
+
+import com.lewns2.backend.model.Member;
+import com.lewns2.backend.model.Role;
+import com.lewns2.backend.rest.dto.MemberDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemberMapperTests {
+
+    @Test
+    public void toMemberDto_테스트() {
+        // given
+        Member memberA = new Member();
+        memberA.setEmail("test@naver.com");
+
+        // when
+        MemberDto memberDto = MemberMapper.INSTANCE.toMemberDto(memberA);
+
+        // then
+        assertThat(memberDto).isNotNull();
+        assertThat(memberDto.getEmail()).isEqualTo("test@naver.com");
+    }
+
+    @Test
+    public void toMember_테스트() {
+        // given
+        Member memberA = new Member();
+        memberA.setEmail("test2@naver.com");
+
+        // when
+        MemberDto memberDto = MemberMapper.INSTANCE.toMemberDto(memberA);
+
+        Member newMember = MemberMapper.INSTANCE.toMember(memberDto);
+
+        // then
+        assertThat(newMember).isNotNull();
+        assertThat(newMember.getEmail()).isEqualTo("test2@naver.com");
+
+    }
+}


### PR DESCRIPTION
**의존성 추가 사항** 
- Rest를 위한 'spring-boot-starter-web' 의존성 추가
- 객체 변환 라이브러리 'MapStruct' 사용을 위한 의존성 추가

**구현**

회원 저장
- API에 엔티티를 노출하지 않기 위한 DTO 사용
- Entity와 DTO 객체 변환을 위한 MapStruct 사용
- 공통 응답 클래스가 없으므로, 임시로 'ResponseEntity'를 반환

**테스트**
- Entitiy to Dto 테스트
- Dto to Entity 테스트 

**비고**
- Dto 클래스에 대한 고민을 해야함. (여러 API에 대응하기 위한 Dto 클래스 설계는 무엇인지?)
- Rest에서의 응답을 어떻게 할 것인지 고민해야 함.
