### PR TITLE
[BE] add: findMember by nickName and test, add: board CRD api

### DIFF
--- a/backend/src/main/java/com/lewns2/backend/model/Member.java
+++ b/backend/src/main/java/com/lewns2/backend/model/Member.java
@@ -8,6 +8,9 @@ import javax.persistence.*;
 @Table(name = "members")
 public class Member extends BaseEntity {
 
+    @Column(name = "nickname")
+    private String nickname;
+
     @Column(name = "email")
     private String email;
 
@@ -23,8 +26,9 @@ public class Member extends BaseEntity {
 
     // 생성자
     @Builder // 빌더 패턴을 위함.
-    public Member(String email, String password, Role role) {
+    public Member(String nickname, String email, String password, Role role) {
         this.id = id;
+        this.nickname = nickname;
         this.email = email;
         this.password = password;
         this.role = role;
@@ -61,5 +65,13 @@ public class Member extends BaseEntity {
 
     public void setRole(Role role) {
         this.role = role;
+    }
+
+    public String getNickName() {
+        return nickname;
+    }
+
+    public void setNickName(String nickName) {
+        this.nickname = nickName;
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/repository/BoardRepository.java
+++ b/backend/src/main/java/com/lewns2/backend/repository/BoardRepository.java
@@ -1,10 +1,8 @@
 package com.lewns2.backend.repository;
 
 import com.lewns2.backend.model.Board;
-import com.lewns2.backend.model.Url;
 
 import java.util.List;
-import java.util.Set;
 
 public interface BoardRepository {
 
@@ -14,5 +12,5 @@ public interface BoardRepository {
 
     List<Board> findByMemberId(Long memberId);
 
-    void delete(Board board);
+    void delete(Long boardId);
 }

--- a/backend/src/main/java/com/lewns2/backend/repository/MemberRepository.java
+++ b/backend/src/main/java/com/lewns2/backend/repository/MemberRepository.java
@@ -7,4 +7,6 @@ public interface MemberRepository{
     void save(Member member);
 
     Member findMemberById(Long memberId);
+
+    Member findMemberByNickName(String nickName);
 }

--- a/backend/src/main/java/com/lewns2/backend/repository/jpa/JpaBoardRepositoryImpl.java
+++ b/backend/src/main/java/com/lewns2/backend/repository/jpa/JpaBoardRepositoryImpl.java
@@ -35,8 +35,7 @@ public class JpaBoardRepositoryImpl implements BoardRepository {
     }
 
     @Override
-    public void delete(Board board) {
-        String boardId = board.getId().toString();
+    public void delete(Long boardId) {
         this.em.createQuery("DELETE FROM Board board WHERE id=" + boardId).executeUpdate();
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/repository/jpa/JpaMemberRepositoryImpl.java
+++ b/backend/src/main/java/com/lewns2/backend/repository/jpa/JpaMemberRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.lewns2.backend.repository.jpa;
 
 import com.lewns2.backend.model.Member;
 import com.lewns2.backend.repository.MemberRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
@@ -21,6 +22,17 @@ public class JpaMemberRepositoryImpl implements MemberRepository {
     @Override
     public Member findMemberById(Long memberId) {
         Member findMember = this.em.find(Member.class, memberId);
+        return findMember;
+    }
+
+    @Override
+    public Member findMemberByNickName(String nickname) {
+        String qlString = "select m from Member m where m.nickname= :nickname";
+
+        Member findMember = this.em.createQuery(qlString, Member.class).setParameter("nickname", nickname).getSingleResult();
+//        Query query = this.em.createQuery("select m from member m where m.nickname" + nickName);
+//        Member findMember = query.getSingleResult();
+
         return findMember;
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/repository/memory/MemoryBoardRepositoryImpl.java
+++ b/backend/src/main/java/com/lewns2/backend/repository/memory/MemoryBoardRepositoryImpl.java
@@ -29,7 +29,7 @@ public class MemoryBoardRepositoryImpl implements BoardRepository {
     }
 
     @Override
-    public void delete(Board board) {
-
+    public void delete(Long boardId) {
+        return;
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/repository/memory/MemoryMemberRepositoryImpl.java
+++ b/backend/src/main/java/com/lewns2/backend/repository/memory/MemoryMemberRepositoryImpl.java
@@ -20,4 +20,11 @@ public class MemoryMemberRepositoryImpl implements MemberRepository {
     public Member findMemberById(Long memberId) {
         return store.get(memberId);
     }
+
+    @Override
+    public Member findMemberByNickName(String nickName) {
+        return null;
+    }
+
+
 }

--- a/backend/src/main/java/com/lewns2/backend/rest/controller/BoardRestController.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/controller/BoardRestController.java
@@ -1,32 +1,53 @@
 package com.lewns2.backend.rest.controller;
 
 import com.lewns2.backend.model.Board;
+import com.lewns2.backend.model.Member;
 import com.lewns2.backend.rest.dto.board.BoardResponse;
 import com.lewns2.backend.rest.dto.board.CreateBoardRequest;
 import com.lewns2.backend.service.BoardService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import com.lewns2.backend.service.MemberService;
+import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import java.util.Collection;
 
 @RestController
 public class BoardRestController {
 
     private final BoardService boardService;
+    private final MemberService memberService;
 
     // 생성자
-    public BoardRestController(BoardService boardService) {
+    public BoardRestController(BoardService boardService, MemberService memberService) {
         this.boardService = boardService;
+        this.memberService = memberService;
     }
 
     // 게시글 작성
     @PostMapping("/board")
     public BoardResponse createBoard(@RequestBody CreateBoardRequest request) {
-        Board board = request.toEntity();
+        String memberNickName = request.getNickname();
+        Member member = memberService.findMemberByNickName(memberNickName);
+
+        Board board = request.toEntity(member);
         Long id = boardService.doSaveArticle(board);
 
         return BoardResponse.from(id);
+    }
+
+    // 게시글 조회
+    @GetMapping("/board/{nickName}")
+    public Collection<Board> getBoard(@PathVariable String nickName) {
+        Member member = memberService.findMemberByNickName(nickName);
+        System.out.println(member);
+        Collection<Board> boardRes = boardService.findBoardByMemberId(member.getId());
+        return boardRes;
+    }
+
+    // 게시글 삭제
+    @DeleteMapping("/board/{id}")
+    public void deleteBoard(@PathVariable int id) {
+        Long boardId = Long.valueOf(id);
+        boardService.deleteArticle(boardId);
+        return;
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/rest/dto/board/CreateBoardRequest.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/dto/board/CreateBoardRequest.java
@@ -4,19 +4,23 @@ package com.lewns2.backend.rest.dto.board;
 import com.lewns2.backend.model.Board;
 import com.lewns2.backend.model.Member;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class CreateBoardRequest {
 
-    private Member member;
+    private String nickname;
     private String title;
     private String description;
 
     // Dto to Entity
-    public Board toEntity() {
+    public Board toEntity(Member member) {
+
         return Board.builder()
                 .member(member)
                 .title(title)

--- a/backend/src/main/java/com/lewns2/backend/rest/dto/member/SignUpRequest.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/dto/member/SignUpRequest.java
@@ -3,12 +3,14 @@ package com.lewns2.backend.rest.dto.member;
 import com.lewns2.backend.model.Member;
 
 public class SignUpRequest {
+    private String nickname;
     private String email;
     private String password;
 
     // 빌더 패턴
     public Member toEntity() {
         return Member.builder()
+                .nickname(nickname)
                 .email(email)
                 .password(password)
                 .build();
@@ -32,5 +34,13 @@ public class SignUpRequest {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public String getNickName() {
+        return nickname;
+    }
+
+    public void setNickName(String nickName) {
+        this.nickname = nickName;
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/service/BoardService.java
+++ b/backend/src/main/java/com/lewns2/backend/service/BoardService.java
@@ -1,6 +1,7 @@
 package com.lewns2.backend.service;
 
 import com.lewns2.backend.model.Board;
+import com.lewns2.backend.model.Member;
 import com.lewns2.backend.model.Url;
 
 import java.util.Collection;
@@ -13,6 +14,6 @@ public interface BoardService {
 
     Collection<Board> findBoardByMemberId(Long memberId);
 
-    void deleteArticle(Board board);
+    void deleteArticle(Long boardId);
 
 }

--- a/backend/src/main/java/com/lewns2/backend/service/BoardServiceImpl.java
+++ b/backend/src/main/java/com/lewns2/backend/service/BoardServiceImpl.java
@@ -1,6 +1,7 @@
 package com.lewns2.backend.service;
 
 import com.lewns2.backend.model.Board;
+import com.lewns2.backend.model.Member;
 import com.lewns2.backend.model.Url;
 import com.lewns2.backend.repository.BoardRepository;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,7 @@ public class BoardServiceImpl implements BoardService{
 
     @Override
     @Transactional
-    public void deleteArticle(Board board) {
-        boardRepository.delete(board);
+    public void deleteArticle(Long boardId) {
+        boardRepository.delete(boardId);
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/service/MemberService.java
+++ b/backend/src/main/java/com/lewns2/backend/service/MemberService.java
@@ -9,4 +9,6 @@ public interface MemberService {
 
     Member findMember(Long memberId);
 
+    Member findMemberByNickName(String nickname);
+
 }

--- a/backend/src/main/java/com/lewns2/backend/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/lewns2/backend/service/MemberServiceImpl.java
@@ -30,5 +30,10 @@ public class MemberServiceImpl implements MemberService {
         return memberRepository.findMemberById(memberId);
     }
 
+    @Override
+    @Transactional
+    public Member findMemberByNickName(String nickname) {
+        return memberRepository.findMemberByNickName(nickname);
+    }
 
 }

--- a/backend/src/test/java/com/lewns2/backend/service/board/BoardServiceJpaTests.java
+++ b/backend/src/test/java/com/lewns2/backend/service/board/BoardServiceJpaTests.java
@@ -69,7 +69,7 @@ public class BoardServiceJpaTests {
     @Transactional
     void 게시글_저장_테스트() throws Exception {
         // given
-        Member memberA = new Member("zlewns@gmail.com", "123", Role.USER);
+        Member memberA = new Member("dh", "zlewns@gmail.com", "123", Role.USER);
         memberService.doSignUp(memberA);
 
         Board board = new Board(memberA, "제목", "설명");
@@ -88,7 +88,7 @@ public class BoardServiceJpaTests {
     @Transactional
     void 특정회원_작성_게시글들_조회_테스트() throws Exception {
         // given
-        Member memberA = new Member("zlewns@gmail.com", "123", Role.USER);
+        Member memberA = new Member("dh","zlewns@gmail.com", "123", Role.USER);
         memberService.doSignUp(memberA);
 
         Board boardA = new Board(memberA, "제목1", "설명1");
@@ -109,15 +109,15 @@ public class BoardServiceJpaTests {
     @Transactional // javax.persistence.TransactionRequiredException: Executing an update/delete query
     void 게시글_삭제_테스트() throws Exception {
         // given
-        Member memberA = new Member("zlewns@gmail.com", "123", Role.USER);
+        Member memberA = new Member("dh", "zlewns@gmail.com", "123", Role.USER);
         memberService.doSignUp(memberA);
 
         Board boardA = new Board(memberA, "제목444", "설명444");
         boardService.doSaveArticle(boardA);
 
         // when
-        Board findBoard = this.boardService.findBoardById(1L);
-        boardService.deleteArticle(findBoard);
+//        Board findBoard = this.boardService.findBoardById(1L);
+        boardService.deleteArticle(1L);
 
         // then
         Assertions.assertThat(boardRepository.findByMemberId(1L)).isEmpty();

--- a/backend/src/test/java/com/lewns2/backend/service/member/MemberServiceJpaTests.java
+++ b/backend/src/test/java/com/lewns2/backend/service/member/MemberServiceJpaTests.java
@@ -46,7 +46,7 @@ public class MemberServiceJpaTests {
     @Transactional
     public void 회원등록_테스트() throws Exception {
         // given
-        Member memberA = new Member("test1@gmail.com", "test1", Role.USER);
+        Member memberA = new Member("dh", "test1@gmail.com", "test1", Role.USER);
 
         // when
         memberService.doSignUp(memberA);
@@ -61,11 +61,18 @@ public class MemberServiceJpaTests {
 
         // 문제) 기본키 값은 초기화되지 않아 계속 올라간다.
         Member findMemberA = memberService.findMember(1L);
+        Member findMemberB = memberService.findMemberByNickName("dh");
+        System.out.println(findMemberA);
+        System.out.println(findMemberB);
 
         // then
         Assertions.assertThat(findMemberA.getEmail()).isEqualTo(memberA.getEmail());
         Assertions.assertThat(findMemberA.getPassword()).isEqualTo(memberA.getPassword());
         Assertions.assertThat(findMemberA.getRole()).isEqualTo(memberA.getRole());
+
+        Assertions.assertThat(findMemberB.getEmail()).isEqualTo(memberA.getEmail());
+        Assertions.assertThat(findMemberB.getPassword()).isEqualTo(memberA.getPassword());
+        Assertions.assertThat(findMemberB.getRole()).isEqualTo(memberA.getRole());
 
 
         // 회원을 찾을 때마다 매번 Member@xxxx, xxx의 값들(참조)이 계속 바뀐다. 왜??

--- a/backend/src/test/java/com/lewns2/backend/service/url/UrlServiceJpaTests.java
+++ b/backend/src/test/java/com/lewns2/backend/service/url/UrlServiceJpaTests.java
@@ -67,7 +67,7 @@ public class UrlServiceJpaTests {
     @Transactional
     void URL_저장_테스트() {
         // given
-        Member memberA = new Member("url@test.com", "123", Role.USER);
+        Member memberA = new Member("dh", "url@test.com", "123", Role.USER);
         memberService.doSignUp(memberA);
 
         Board boardA = new Board(memberA, "url-test", "url-description");
@@ -92,7 +92,7 @@ public class UrlServiceJpaTests {
     @Transactional
     void URL_삭제_테스트() {
         // given
-        Member memberA = new Member("url@test.com", "1234", Role.USER);
+        Member memberA = new Member("dh", "url@test.com", "1234", Role.USER);
         memberService.doSignUp(memberA);
 
         Board boardA = new Board(memberA, "url-test", "url-description");


### PR DESCRIPTION
**추가 사항**
- 회원 도메인에 nickname 추가
- 닉네임을 통한 회원 조회
- 게시글 작성, 조회, 삭제 api
- 닉네임 조회에 대한 테스트 코드

**변경 이유**
- 기존 : memberId를 통한 회원 조회 
- 변경 : nickname을 통한 회원 조회 
- 이유 : view 레이어에서 memberId가 사용되지 않기에, 굳이 이를 가지고 있을 필요가 없다. 따라서 요청을 위한 memberId를 가지고 있기보다, 화면에 사용되는 닉네임을 가지고 요청을 보내는 것이 올바르다 생각함.

**할 일**
- 각 요청에 대한 응답 알맞은 DTO 작성
- Validation : 닉네임 중복 여부