### PR TITLE
[BE] add: save board with URLs, update board

### DIFF
--- a/backend/src/main/java/com/lewns2/backend/rest/controller/BoardRestController.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/controller/BoardRestController.java
@@ -1,20 +1,22 @@
 package com.lewns2.backend.rest.controller;
 
-import ch.qos.logback.classic.html.UrlCssBuilder;
 import com.lewns2.backend.model.Board;
 import com.lewns2.backend.model.Member;
 import com.lewns2.backend.model.Url;
 import com.lewns2.backend.rest.dto.board.BoardResponse;
 import com.lewns2.backend.rest.dto.board.CreateBoardRequest;
+import com.lewns2.backend.rest.dto.board.UpdateBoardRequest;
 import com.lewns2.backend.service.BoardService;
 import com.lewns2.backend.service.MemberService;
 import com.lewns2.backend.service.UrlService;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collection;
 
 @RestController
+@RequestMapping("/api")
 public class BoardRestController {
 
     private final BoardService boardService;
@@ -30,11 +32,14 @@ public class BoardRestController {
 
     // 게시글 작성
     @PostMapping("/board")
-    public BoardResponse createBoard(@RequestBody CreateBoardRequest request) {
+    public ResponseEntity<BoardResponse>  createBoard(@RequestBody CreateBoardRequest request) {
 
         // 회원 조회
-        String memberNickName = request.getNickname();
+        String memberNickName = request.getNickName();
         Member member = memberService.findMemberByNickName(memberNickName);
+        if(member == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
 
         // 게시글 작성
         Board board = request.toEntity(member);
@@ -44,22 +49,40 @@ public class BoardRestController {
         Collection<Url> urls = request.toEntityUrl(board, request.getUrls());
         urlService.doSaveUrls(urls);
 
-        return BoardResponse.from(id);
+        return new ResponseEntity<>(BoardResponse.from(id), HttpStatus.OK);
     }
 
     // 게시글 조회
     @GetMapping("/board/{nickName}")
-    public Collection<Board> getBoard(@PathVariable String nickName) {
+    public ResponseEntity<Collection<Board>> getBoard(@PathVariable String nickName) {
         Member member = memberService.findMemberByNickName(nickName);
         Collection<Board> boardRes = boardService.findBoardByMemberId(member.getId());
-        return boardRes;
+
+        return new ResponseEntity<>(boardRes, HttpStatus.OK);
     }
 
     // 게시글 삭제
     @DeleteMapping("/board/{id}")
-    public void deleteBoard(@PathVariable int id) {
+    public ResponseEntity<?> deleteBoard(@PathVariable int id) {
         Long boardId = Long.valueOf(id);
         boardService.deleteArticle(boardId);
-        return;
+        return new ResponseEntity<>(HttpStatus.OK);
     }
+
+    // 게시글 수정
+    @PutMapping("/board/{id}")
+    public Long updateBoard(@RequestBody UpdateBoardRequest request, @PathVariable int id) {
+
+        // 회원 조회
+        String memberNickName = request.getNickName();  // ??
+        Member member = memberService.findMemberByNickName(memberNickName);
+
+        Long boardId = Long.valueOf(id);
+        Board board = request.toEntity(member);
+
+        Long resId = boardService.updateArticle(board, boardId);
+
+        return resId;
+    }
+
 }

--- a/backend/src/main/java/com/lewns2/backend/rest/controller/MemberRestController.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/controller/MemberRestController.java
@@ -4,13 +4,16 @@ import com.lewns2.backend.model.Member;
 import com.lewns2.backend.rest.dto.member.MemberResponse;
 import com.lewns2.backend.rest.dto.member.SignUpRequest;
 import com.lewns2.backend.service.MemberService;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
 @RestController
+@RequestMapping("/api")
 public class MemberRestController {
 
     private final MemberService memberService;
@@ -22,7 +25,7 @@ public class MemberRestController {
 
     // 회원 등록
     @PostMapping("/signup")
-    public MemberResponse addMember(@RequestBody SignUpRequest signUpRequest) {
+    public ResponseEntity<MemberResponse> addMember(@RequestBody SignUpRequest signUpRequest) {
         /* 1. 요청 memberDto를 member 엔티티로 변환
         // 2. 서비스 호출 : 등록
         // 3, dto를 반환 */
@@ -37,6 +40,6 @@ public class MemberRestController {
         member.setPassword(signUpRequest.getPassword()); */
 
         Long id = memberService.doSignUp(member);
-        return MemberResponse.from(id); // 3. 정적 팩토리 메서드 패턴
+        return new ResponseEntity<>(MemberResponse.from(id), HttpStatus.OK);  // 3. 정적 팩토리 메서드 패턴
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/rest/dto/board/CreateBoardRequest.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/dto/board/CreateBoardRequest.java
@@ -34,7 +34,7 @@ public class CreateBoardRequest {
         }
     }
 
-    private String nickname;
+    private String nickName;
     private String title;
     private String description;
     private List<UrlReq> urls;

--- a/backend/src/main/java/com/lewns2/backend/rest/dto/board/UpdateBoardRequest.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/dto/board/UpdateBoardRequest.java
@@ -1,0 +1,31 @@
+package com.lewns2.backend.rest.dto.board;
+
+
+import com.lewns2.backend.model.Board;
+import com.lewns2.backend.model.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.sql.Update;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateBoardRequest {
+
+    private String nickName;
+    private String title;
+    private String description;
+
+    public UpdateBoardRequest(String nickName) {
+        this.nickName = nickName;
+    }
+
+    public Board toEntity(Member member) {
+        return Board.builder()
+                .member(member)
+                .title(title)
+                .description(description)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/lewns2/backend/service/BoardService.java
+++ b/backend/src/main/java/com/lewns2/backend/service/BoardService.java
@@ -16,4 +16,6 @@ public interface BoardService {
 
     void deleteArticle(Long boardId);
 
+    Long updateArticle(Board board, Long boardId);
+
 }

--- a/backend/src/main/java/com/lewns2/backend/service/BoardServiceImpl.java
+++ b/backend/src/main/java/com/lewns2/backend/service/BoardServiceImpl.java
@@ -41,4 +41,18 @@ public class BoardServiceImpl implements BoardService{
     public void deleteArticle(Long boardId) {
         boardRepository.delete(boardId);
     }
+
+    @Override
+    @Transactional
+    public Long updateArticle(Board board, Long boardId) {
+        Board findBoard = this.findBoardById(boardId);
+        if(board.getTitle() != null) {
+            findBoard.setTitle(board.getTitle());
+        }
+        if(board.getDescription() != null) {
+            findBoard.setDescription(board.getDescription());
+        }
+        return boardId;
+    }
+
 }


### PR DESCRIPTION
[직전 커밋 내용](https://github.com/lewns2/manageURL/commit/9bfcb23955368ac13c9cc3e9632997f1d430ab4b)도 함께 포함되어 있음.

추가 사항
-  기능
    - `DTO(CreateBoardReqeust)` URL 로직 추가: 게시글 작성 시, URL들도 함께 저장한다.
    - `게시글 수정`: 제목, 설명에 한해서.
    - `DTO(UpdateBoardRequest)` 추가: 게시글 수정을 위한 DTO이다.

- Config
  - `@Bean`: 스프링 컨테이너에 `UrlService` 등록

변경 사항
- `Controller 응답` - `ResponseEntity<>` 타입으로 변환
- 요청 prefix 추가 - `/api`추가

비고
- 게시글 수정 요청 시, nickname 수신 여부 판단 필요
- 요청 URL들의 엔티티 변환 방법에 대한 고민 필요