### PR TITLE
[FE] fix: `SingleUrlData`를 제어 컴포넌트에서 비제어 컴포넌트로 변경

### DIFF
--- a/frontend/src/pages/board/board-main/board-create/create-form/parts/create-urlList/create-url/CreateUrl.jsx
+++ b/frontend/src/pages/board/board-main/board-create/create-form/parts/create-urlList/create-url/CreateUrl.jsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react';
+import { Fragment, useRef } from 'react';
 
 import { useBoardCreateContext } from '../../../hooks';
 
@@ -20,23 +20,27 @@ const CreateUrl = (props) => {
   );
 };
 
-// Component : 하나의 URL 인풋 데이터 관리 컴포넌트 => 문제점 : state 변경에 따른 input 한글자 후 focus 잃음.
+// Component : 하나의 URL 인풋 데이터 관리 컴포넌트 => 문제점 : state 변경에 따른 input 한글자 후 focus 잃음. => 비제어 컴포넌트로 변경
 const SingleUrlData = (props) => {
-  const [url, setUrl] = useState({ address: '', category: '' });
+  const url = {
+    address: '',
+    category: '',
+  };
+  const addressInputRef = useRef();
+  const categoryInputRef = useRef();
 
-  const handleData = (e) => {
-    const { name, value } = e.target;
-    setUrl({ ...url, [name]: value || '' });
-    console.log(url);
+  const handleData = () => {
+    url.address = addressInputRef.current.value;
+    url.category = categoryInputRef.current.value;
     props.urlArr[props.index] = url;
   };
 
   return (
     <Fragment>
       <label>URL 주소 : </label>
-      <input onChange={(e) => handleData(e)} name="address"></input>
+      <input onChange={() => handleData()} name="address" ref={addressInputRef}></input>
       <label> 카테고리 : </label>
-      <input onChange={(e) => handleData(e)} name="category"></input>
+      <input onChange={() => handleData()} name="category" ref={categoryInputRef}></input>
       <button>삭제</button>
     </Fragment>
   );


### PR DESCRIPTION
- **기존 문제** : input에서 입력하는 첫 글자는 변경되지 않는 문제.
- **원인** : setState()를 통한 상태 변경으로 하위 컴포넌트의 리렌더링이 발생 --> input을 포커스를 잃는다.
- **해결** : 제어 컴포넌트를 비제어 컴포넌트로 변경하여 리렌더링 방지.