### PR TITLE
[BE] add: 단일 게시글 조회

### DIFF
--- a/backend/src/main/java/com/lewns2/backend/model/Board.java
+++ b/backend/src/main/java/com/lewns2/backend/model/Board.java
@@ -1,5 +1,6 @@
 package com.lewns2.backend.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.CreatedDate;
@@ -24,7 +25,7 @@ public class Board extends DateEntity {
     private String description;
 
     @OneToMany(mappedBy = "board")
-    private Set<Url> urls;
+    private List<Url> urls;
 
     // JPA를 위한 기본 생성자
     public Board() {};
@@ -60,5 +61,13 @@ public class Board extends DateEntity {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public List<Url> getUrls() {
+        return urls;
+    }
+
+    public void setUrls(List<Url> urls) {
+        this.urls = urls;
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/model/DateEntity.java
+++ b/backend/src/main/java/com/lewns2/backend/model/DateEntity.java
@@ -1,6 +1,7 @@
 package com.lewns2.backend.model;
 
 
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -9,6 +10,7 @@ import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import java.time.LocalDate;
 
+@Getter
 @MappedSuperclass
 public class DateEntity extends BaseEntity {
     @CreatedDate

--- a/backend/src/main/java/com/lewns2/backend/model/Url.java
+++ b/backend/src/main/java/com/lewns2/backend/model/Url.java
@@ -1,6 +1,7 @@
 package com.lewns2.backend.model;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 
 import javax.persistence.*;
@@ -9,6 +10,7 @@ import javax.persistence.*;
 @Table(name = "urls")
 public class Url extends DateEntity{
 
+    @JsonIgnore
     @ManyToOne
     Board board;
 

--- a/backend/src/main/java/com/lewns2/backend/repository/BoardRepository.java
+++ b/backend/src/main/java/com/lewns2/backend/repository/BoardRepository.java
@@ -3,12 +3,13 @@ package com.lewns2.backend.repository;
 import com.lewns2.backend.model.Board;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BoardRepository {
 
     void save(Board board);
 
-    Board findById(Long boardId);
+    Optional<Board> findById(Long boardId);
 
     List<Board> findByMemberId(Long memberId);
 

--- a/backend/src/main/java/com/lewns2/backend/repository/jpa/JpaBoardRepositoryImpl.java
+++ b/backend/src/main/java/com/lewns2/backend/repository/jpa/JpaBoardRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.lewns2.backend.repository.jpa;
 
 import com.lewns2.backend.model.Board;
+import com.lewns2.backend.model.Member;
 import com.lewns2.backend.model.Url;
 import com.lewns2.backend.repository.BoardRepository;
 import org.springframework.stereotype.Repository;
@@ -9,6 +10,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Repository
@@ -23,8 +25,14 @@ public class JpaBoardRepositoryImpl implements BoardRepository {
     }
 
     @Override
-    public Board findById(Long boardId) {
-        return this.em.find(Board.class, boardId);
+    public Optional<Board> findById(Long boardId) {
+
+        try {
+            return Optional.of(this.em.find(Board.class, boardId));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+
     }
 
     @Override

--- a/backend/src/main/java/com/lewns2/backend/repository/memory/MemoryBoardRepositoryImpl.java
+++ b/backend/src/main/java/com/lewns2/backend/repository/memory/MemoryBoardRepositoryImpl.java
@@ -1,35 +1,35 @@
-package com.lewns2.backend.repository.memory;
-
-import com.lewns2.backend.model.Board;
-import com.lewns2.backend.model.Url;
-import com.lewns2.backend.repository.BoardRepository;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-public class MemoryBoardRepositoryImpl implements BoardRepository {
-
-    // 임시 저장소
-    private static Map<Long, Board> store = new ConcurrentHashMap<>();
-
-    @Override
-    public void save(Board board) {
-        store.put(board.getId(), board);
-    }
-
-    @Override
-    public Board findById(Long boardId) {
-        return null;
-    }
-
-    @Override
-    public List<Board> findByMemberId(Long memberId) {
-        return null;
-    }
-
-    @Override
-    public void delete(Long boardId) {
-        return;
-    }
-}
+//package com.lewns2.backend.repository.memory;
+//
+//import com.lewns2.backend.model.Board;
+//import com.lewns2.backend.model.Url;
+//import com.lewns2.backend.repository.BoardRepository;
+//
+//import java.util.List;
+//import java.util.Map;
+//import java.util.concurrent.ConcurrentHashMap;
+//
+//public class MemoryBoardRepositoryImpl implements BoardRepository {
+//
+//    // 임시 저장소
+//    private static Map<Long, Board> store = new ConcurrentHashMap<>();
+//
+//    @Override
+//    public void save(Board board) {
+//        store.put(board.getId(), board);
+//    }
+//
+//    @Override
+//    public Board findById(Long boardId) {
+//        return null;
+//    }
+//
+//    @Override
+//    public List<Board> findByMemberId(Long memberId) {
+//        return null;
+//    }
+//
+//    @Override
+//    public void delete(Long boardId) {
+//        return;
+//    }
+//}

--- a/backend/src/main/java/com/lewns2/backend/rest/controller/board/BoardRestController.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/controller/board/BoardRestController.java
@@ -6,6 +6,7 @@ import com.lewns2.backend.model.Url;
 import com.lewns2.backend.rest.dto.board.response.BoardIdResponse;
 import com.lewns2.backend.rest.dto.board.request.CreateBoardRequest;
 import com.lewns2.backend.rest.dto.board.request.UpdateBoardRequest;
+import com.lewns2.backend.rest.dto.board.response.BoardResponse;
 import com.lewns2.backend.rest.dto.board.response.BoardsResponse;
 import com.lewns2.backend.service.board.BoardService;
 import com.lewns2.backend.service.member.MemberService;
@@ -55,7 +56,7 @@ public class BoardRestController {
 
     // 게시글 조회
     @GetMapping("/board/{nickName}")
-    public ResponseEntity<BoardsResponse> getBoard(@PathVariable String nickName) {
+    public ResponseEntity<BoardsResponse> getBoards(@PathVariable String nickName) {
         Member member = memberService.findMemberByNickName(nickName);
         Collection<Board> boardRes = boardService.findBoardByMemberId(member.getId());
 
@@ -89,5 +90,16 @@ public class BoardRestController {
 
         return new ResponseEntity<>(resId, HttpStatus.OK);
     }
+
+    // 단일 게시글 조회
+    @GetMapping("/board/{nickName}/{id}")
+    public ResponseEntity<BoardResponse> getBoard(@PathVariable("nickName") String nickName, @PathVariable("id") int id) {
+        Long boardId = Long.valueOf(id);
+        Board board = boardService.findBoardById(boardId);
+
+        return new ResponseEntity<>(BoardResponse.getBoardWithUrls(board), HttpStatus.OK);
+    }
+
+
 
 }

--- a/backend/src/main/java/com/lewns2/backend/rest/dto/board/response/BoardResponse.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/dto/board/response/BoardResponse.java
@@ -1,21 +1,48 @@
 package com.lewns2.backend.rest.dto.board.response;
 
 import com.lewns2.backend.model.Board;
+import com.lewns2.backend.model.Url;
 import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class BoardResponse {
+    Long boardId;
     String title;
     String description;
+    LocalDate createDate;
+    LocalDate updateDate;
+    List Urls;
 
     private BoardResponse() {};
 
-    private BoardResponse(String title, String description) {
+    private BoardResponse(Long boardId, String title, String description, LocalDate createDate, LocalDate updateDate) {
+        this.boardId = boardId;
         this.title = title;
         this.description = description;
+        this.createDate = createDate;
+        this.updateDate = updateDate;
     }
 
-    public static BoardResponse from(final Board board) {
-        return new BoardResponse(board.getTitle(), board.getDescription());
+    private BoardResponse(Long boardId, String title, String description, LocalDate createDate, LocalDate updateDate, List urls) {
+        this.boardId = boardId;
+        this.title = title;
+        this.description = description;
+        this.createDate = createDate;
+        this.updateDate = updateDate;
+        this.Urls = urls;
+    }
+
+    public static BoardResponse getBoardWithoutUrls(final Board board) {
+        return new BoardResponse(board.getId(), board.getTitle(), board.getDescription(), board.getCreatedDate(), board.getUpdateDate());
+    }
+
+    public static BoardResponse getBoardWithUrls(final Board board) {
+        return new BoardResponse(board.getId(), board.getTitle(), board.getDescription(), board.getCreatedDate(), board.getUpdateDate(), board.getUrls());
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/rest/dto/board/response/BoardsResponse.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/dto/board/response/BoardsResponse.java
@@ -19,6 +19,6 @@ public class BoardsResponse {
     }
 
     public static BoardsResponse from(Collection<Board> boards) {
-        return new BoardsResponse(boards.stream().map(BoardResponse::from).collect(Collectors.toList()));
+        return new BoardsResponse(boards.stream().map(BoardResponse::getBoardWithoutUrls).collect(Collectors.toList()));
     }
 }

--- a/backend/src/main/java/com/lewns2/backend/rest/exception/ErrorCode.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
     INVALID_PASSWORD_PARAM("400"),
 
     //
-    MEMBER_NOT_FOUND("404");
+    MEMBER_NOT_FOUND("404"),
+    BOARD_NOT_FOUND("404");
 
 
     private final String value;

--- a/backend/src/main/java/com/lewns2/backend/rest/exception/notfound/BoardNotFoundException.java
+++ b/backend/src/main/java/com/lewns2/backend/rest/exception/notfound/BoardNotFoundException.java
@@ -1,0 +1,10 @@
+package com.lewns2.backend.rest.exception.notfound;
+
+import com.lewns2.backend.rest.exception.ErrorCode;
+
+public class BoardNotFoundException extends NotFoundException{
+
+    public BoardNotFoundException() {
+        super(ErrorCode.BOARD_NOT_FOUND, "해당 게시글을 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/lewns2/backend/service/board/BoardServiceImpl.java
+++ b/backend/src/main/java/com/lewns2/backend/service/board/BoardServiceImpl.java
@@ -2,6 +2,7 @@ package com.lewns2.backend.service.board;
 
 import com.lewns2.backend.model.Board;
 import com.lewns2.backend.repository.BoardRepository;
+import com.lewns2.backend.rest.exception.notfound.BoardNotFoundException;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -26,7 +27,10 @@ public class BoardServiceImpl implements BoardService{
     @Override
     @Transactional
     public Board findBoardById(Long boardId) {
-        return boardRepository.findById(boardId);
+
+        Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
+
+        return board;
     }
 
     @Override


### PR DESCRIPTION
**단일 게시글 조회**
```
http://localhost:8080/api/board/{nickname}/{id}
```

**추가 사항**
- 존재하지 않는 게시글 조회 시,  `MemberNotFoundExceoption` 오류 반환
- DTO `BoardResponse`에서 URL 데이터를 포함한 정적 팩터리 메서드 구현

**변경 사항** 
- 게시글 `findById`의 반환 타입을 `Optional`로 변환
- `BoardResponse`에 `boardId`, `생성일`, `수정일` 추가

**문제 상황 / 해결**
- JPA 무한 순환 참조 / `JsonIgnore` 사용
- [ ] 문제 상황을 올바르게 파악해 더 좋은 해결 방안에 대해 공부하기